### PR TITLE
Update testsite.gejson

### DIFF
--- a/batchTester/testSites.geojson
+++ b/batchTester/testSites.geojson
@@ -3324,7 +3324,7 @@
                     },
                     {
                         "Label": "PRECIP",
-                        "Value": 39.3
+                        "Value": 36.2
                     },
                     {
                         "Label": "STREAM_VARG",


### PR DESCRIPTION
OH was previously using the preip at centroid of the basin to calculate precip BC which wasn't working, now it is using mean to calculate precip BC.