### PR TITLE
Update NM basin characteristic I24H100Y in batchTester

### DIFF
--- a/batchTester/testSites.geojson
+++ b/batchTester/testSites.geojson
@@ -3124,7 +3124,7 @@
                     },
                     {
                         "Label": "I24H100Y",
-                        "Value": 3.13
+                        "Value": 3.5
                     },
                     {
                         "Label": "HIGHREG",


### PR DESCRIPTION
The value for I24H100Y in NM was incorrect due to an incorrect XML in Prod. Changing value from 3.13 to 3.5.